### PR TITLE
Navigation between the pages

### DIFF
--- a/Comments.md
+++ b/Comments.md
@@ -1,3 +1,5 @@
+##### [Home](README.md) **Private Libraries:** [Managing Private Libraries](Organization_Management.md) / [Organization Roles](Organization_Roles.md) / [Document Assembly](Document_Assembly.md) / Comments
+
 # Commenting on Content
 
 If Comments are enabled in a Private Library, users will be able to comment and rate Contracts and Clauses. See [Organizational Management](Organization_Management.md) for information on enabling Comments.

--- a/Create_Clause.md
+++ b/Create_Clause.md
@@ -1,3 +1,5 @@
+##### [Home](README.md) | **Creating/Editing Content:** Creating a Clause / [Editing a Clause](Edit_Clause.md) / [Creating a Contract](Create_Contract.md) / [Editing a Contract](Edit_Contract.md)
+
 # Creating a Clause
 
 The "Clause" in ContractStandards is the umbrella page to organize and provide general guidance for the Clause's underlying Clause Alternatives. This is where users will provide general information that applies to that type of Clause. Think key points like a common heading name, general description, and in-depth discussion/guidance.

--- a/Create_Contract.md
+++ b/Create_Contract.md
@@ -1,3 +1,5 @@
+##### [Home](README.md) | **Creating/Editing Content:** [Creating a Clause](Create_Clause.md) / [Editing a Clause](Edit_Clause.md) / Creating a Contract / [Editing a Contract](Edit_Contract.md)
+
 # Create a Contract
 
 1. Login to your ContractStandards Account.

--- a/Document_Assembly.md
+++ b/Document_Assembly.md
@@ -1,3 +1,5 @@
+##### [Home](README.md) **Private Libraries:** [Managing Private Libraries](Organization_Management.md) / [Organization Roles](Organization_Roles.md) / Document Assembly / [Comments](Comments.md)
+
 # Document Assembly
 
 As users provide guidance at the Clause level by tagging Clause Alternatives with labels, party-weight, clause status, and contract type, ContractStandards automatically generates an Assembly solution for a Contract. This article is an overview of how to use the Assembly tool once it is generated. Visit [Editing a Clause](Edit_Clause.md) to learn how to mark up Clauses to generate the Assembly tool.

--- a/Edit_Clause.md
+++ b/Edit_Clause.md
@@ -1,3 +1,5 @@
+##### [Home](README.md) | **Creating/Editing Content:** [Creating a Clause](Create_Clause.md) / Editing a Clause / [Creating a Contract](Create_Contract.md) / [Editing a Contract](Edit_Contract.md)
+
 # Editing a Clause
 
 ## Getting to the Clause Edit Screen

--- a/Edit_Contract.md
+++ b/Edit_Contract.md
@@ -1,3 +1,5 @@
+##### [Home](README.md) | **Creating/Editing Content:** [Creating a Clause](Create_Clause.md) / [Editing a Clause](Edit_Clause.md) / [Creating a Contract](Create_Contract.md) / Editing a Contract
+
 # Edit a Contract
 
 

--- a/Harmonization.md
+++ b/Harmonization.md
@@ -1,3 +1,7 @@
+##### [Home](README.md) **Smart Content:** [Overview](Smart_Content.md) / [Visualizations](Visualization.md) / Harmonization
+
+# Harmonization
+
 Check out the video here to get a detailed walkthrough of Contract Harmonization in ContractStandards:
 
 <a href="http://www.youtube.com/watch?feature=player_embedded&v=-AUDFmUmG9E

--- a/Login.md
+++ b/Login.md
@@ -1,3 +1,5 @@
+##### [Home](README.md) | **Basics Pages:** [Overview](Overview.md) / Log In and Out / [Navigating the Site](Published_View_Navigation.md) / [User Profiles](User_Profile.md)
+
 # Log In and Log Out
 
 ## Log In

--- a/Organization_Management.md
+++ b/Organization_Management.md
@@ -1,3 +1,5 @@
+##### [Home](README.md) **Private Libraries:** Managing Private Libraries / [Organization Roles](Organization_Roles.md) / [Document Assembly](Document_Assembly.md) / [Comments](Comments.md)
+
 # Managing Private Libraries
 
 Admins have a number of options to control access to their Private Libraries and how their content is displayed to other users. Below is an overview of the different Private Library setup options and what they mean for users.

--- a/Organization_Roles.md
+++ b/Organization_Roles.md
@@ -1,3 +1,5 @@
+##### [Home](README.md) **Private Libraries:** [Managing Private Libraries](Organization_Management.md) / Organization Roles / [Document Assembly](Document_Assembly.md) / [Comments](Comments.md)
+
 # Organization Roles
 
 1. Admin. Full access. Admins can edit and publish content as well as invite new users and manage Private Library settings.

--- a/Overview.md
+++ b/Overview.md
@@ -1,4 +1,4 @@
-##### [Home](README.md) | **Basics Pages:** Overview / [Logging In and Out](Login.md) / [Navigating the Site](Published_View_Navigation.md) / [User Profiles](User_Profile.md)
+##### [Home](README.md) | **Basics Pages:** Overview / [Log In and Out](Login.md) / [Navigating the Site](Published_View_Navigation.md) / [User Profiles](User_Profile.md)
 
 # ContractStandards Overview
 

--- a/Overview.md
+++ b/Overview.md
@@ -1,3 +1,5 @@
+##### [Home](README.md) | **Basics Pages:** Overview / [Logging In and Out](Login.md) / [Navigating the Site](Published_View_Navigation.md) / [User Profiles](User_Profile.md)
+
 # ContractStandards Overview
 
 ContractStandards is a platform that allows organizations to create and maintain contract libraries. 
@@ -17,7 +19,3 @@ For a deeper dive into the platform, take a look at these videos:
 1. [Modular Platform](https://youtu.be/eFFJ9U7Vt_0)
 2. [Updating Clauses across Contracts](https://youtu.be/UF6fWDp4kJs)
 3. [Clause Reuse](https://youtu.be/xd5aHNJ6nWc)
-
-
-
- 

--- a/Published_View_Navigation.md
+++ b/Published_View_Navigation.md
@@ -1,3 +1,5 @@
+##### [Home](README.md) | **Basics Pages:** [Overview](Overview.md) / [Log In and Out](Login.md) / Navigating the Site / [User Profiles](User_Profile.md)
+
 # Navigating ContractStandards
 
 ## Generally Getting Around

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 3. [Navigating the Site](Published_View_Navigation.md)
 4. [User Profiles](User_Profile.md)
 
-
 ## Creating/Editing Content
 
 1. [Creating a Clause](Create_Clause.md)
@@ -18,7 +17,6 @@
 1. [Managing Private Libraries](Organization_Management.md)
 2. [Organization Roles](Organization_Roles.md)
 3. [Document Assembly](Document_Assembly.md)
-<!-- 4. [Copying Public Content](Copy_Public_Content.md) -->
 4. [Comments](Comments.md)
 
 ## Smart Content
@@ -26,17 +24,3 @@
 1. [Smart Content Overview](Smart_Content.md)
 2. [Visualizations](Visualization.md)
 3. [Contract Harmonization](Harmonization.md)
-
-<!-- ## User Stories
-
-1. [User Story #1](User_Story_1.md) -->
-
-
-
-
-
-
-
-
-
-

--- a/Smart_Content.md
+++ b/Smart_Content.md
@@ -1,3 +1,5 @@
+##### [Home](README.md) **Smart Content:** Smart Content Overview / [Visualizations](Visualization.md) / [Contract Harmonization](Harmonization.md)
+
 # Smart Content
 
 ContractStandards can be linked with our contract analytics software to give users added functionality such as Harmonization and Visualization. This linking can show users how standard language in the user's Private Library compares to legacy contract language (Harmonization) or generate visualizations on which types of clauses are generally boilerplate, highly negotiated, or optional, deal-specific clauses (Visualization).

--- a/Smart_Content.md
+++ b/Smart_Content.md
@@ -1,4 +1,4 @@
-##### [Home](README.md) **Smart Content:** Overview / [Visualizations](Visualization.md) / [Contract Harmonization](Harmonization.md)
+##### [Home](README.md) **Smart Content:** Overview / [Visualizations](Visualization.md) / [Harmonization](Harmonization.md)
 
 # Smart Content
 

--- a/Smart_Content.md
+++ b/Smart_Content.md
@@ -1,4 +1,4 @@
-##### [Home](README.md) **Smart Content:** Smart Content Overview / [Visualizations](Visualization.md) / [Contract Harmonization](Harmonization.md)
+##### [Home](README.md) **Smart Content:** Overview / [Visualizations](Visualization.md) / [Contract Harmonization](Harmonization.md)
 
 # Smart Content
 

--- a/User_Profile.md
+++ b/User_Profile.md
@@ -1,3 +1,5 @@
+##### [Home](README.md) | **Basics Pages:** [Overview](Overview.md) / [Log In and Out](Login.md) / [Navigating the Site](Published_View_Navigation.md) / User Profiles
+
 # Accessing and Updating User Profile
 
 Users can edit their

--- a/Visualization.md
+++ b/Visualization.md
@@ -1,4 +1,4 @@
-##### [Home](README.md) **Smart Content:** [Smart Content Overview](Smart_Content.md) / Visualizations / [Contract Harmonization](Harmonization.md)
+##### [Home](README.md) **Smart Content:** [Overview](Smart_Content.md) / Visualizations / [Contract Harmonization](Harmonization.md)
 
 # Visualizations (*Smart Feature*)
 

--- a/Visualization.md
+++ b/Visualization.md
@@ -1,4 +1,4 @@
-##### [Home](README.md) **Smart Content:** [Overview](Smart_Content.md) / Visualizations / [Contract Harmonization](Harmonization.md)
+##### [Home](README.md) **Smart Content:** [Overview](Smart_Content.md) / Visualizations / [Harmonization](Harmonization.md)
 
 # Visualizations (*Smart Feature*)
 

--- a/Visualization.md
+++ b/Visualization.md
@@ -1,3 +1,5 @@
+##### [Home](README.md) **Smart Content:** [Smart Content Overview](Smart_Content.md) / Visualizations / [Contract Harmonization](Harmonization.md)
+
 # Visualizations (*Smart Feature*)
 
 The ContractStandards Visualization tool displays a bubble chart showing the commonality and consistency of clause types in a particular type of contract. These statistics are pulled from our machine learning software, KMAuthor.

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,1 @@
-theme: jekyll-theme-leap-day
+theme: jekyll-theme-minimal

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,1 @@
-theme: jekyll-theme-modernist
+theme: jekyll-theme-leap-day

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,1 @@
-theme: jekyll-theme-minimal
+theme: jekyll-theme-modernist


### PR DESCRIPTION
Links on each page to return to home page or view content pages of the same section to facilitate navigation between the CS documentation help site pages